### PR TITLE
[WIP] Add Docker file for cpp-eth with hera and jsonrpcproxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# Docker container spec for building the develop branch of cpp-ethereum.
+#
+# The build process it potentially longer running but every effort was made to
+# produce a very minimalistic container that can be reused many times without
+# needing to constantly rebuild.
+#
+# This image is based on
+# https://github.com/ethereum/cpp-ethereum/blob/ccac1dd777c5b25de1c0bacc72dbecb6b376689e/scripts/docker/eth-alpine/Dockerfile
+
+FROM alpine
+
+# Make sure bash, bc and jq is available for easier wrapper implementation
+RUN apk add --no-cache \
+        bash jq bc \
+        python3 \
+        libstdc++ \
+        gmp \
+        libcurl \
+        libmicrohttpd \
+        leveldb --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    && apk add --no-cache --virtual .build-deps \
+        git \
+        cmake \
+        g++ \
+        make \
+        linux-headers curl-dev libmicrohttpd-dev \
+        leveldb-dev --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ \
+    && sed -i -E -e 's|#warning|//#warning|' /usr/include/sys/poll.h \
+    && git clone --recursive https://github.com/ethereum/cpp-ethereum --branch ewasm --single-branch --depth 1 \
+    && cd cpp-ethereum && echo "{}"                                               \
+            | jq ".+ {\"repo\":\"$(git config --get remote.origin.url)\"}" \
+            | jq ".+ {\"branch\":\"$(git rev-parse --abbrev-ref HEAD)\"}"  \
+            | jq ".+ {\"commit\":\"$(git rev-parse HEAD)\"}"               \
+            > /version.json                                             \
+    && pwd \
+    && cp scripts/jsonrpcproxy.py / \
+    && mkdir /build && cd /build \
+    && cmake /cpp-ethereum -DHERA=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTOOLS=Off -DTESTS=Off \
+    && make eth \
+    && make install \
+    && cd / && rm /build -rf \
+    && rm /cpp-ethereum -rf \
+    && apk del .build-deps \
+    && rm /var/cache/apk/* -f
+
+# See https://github.com/ethereum/cpp-ethereum/issues/3300
+# Using more than j4 can cause failures randomly
+
+# ADD config.json /config.json
+
+ADD ewasm-testnet-cpp-config.json /ewasm-testnet-cpp-config.json
+ADD cpp-eth.sh /cpp-eth.sh
+
+# Export the usual networking ports to allow outside access to the node
+EXPOSE 8545 30303
+
+ENTRYPOINT ["/cpp-eth.sh"]

--- a/cpp-eth.sh
+++ b/cpp-eth.sh
@@ -1,0 +1,2 @@
+#! /bin/bash
+/usr/local/bin/eth --vm hera --evmc fallback=true -d /tmp/ewasm-node/4201 --listen 4201 --no-bootstrap -m on -t 1 -a 0x031159dF845ADe415202e6DA299223cb640B9DB0 --config /ewasm-testnet-cpp-config.json --peerset "required:61e5475e6870260af84bcf61c02b2127a5c84560401452ae9c99b9ff4f0f343d65c9e26209ec32d42028b365addba27824669eb70c73f69568964f77433afbbe@127.0.0.1:1234" --verbosity 12 & python3 /jsonrpcproxy.py /tmp/ewasm-node/4201/geth.ipc


### PR DESCRIPTION
It would be nice to use docker containers in the testnet for ease of deployment.  This PR adds a docker file for cpp-ethereum with hera (and soon jsonrpcproxy).

Right now, I'm running into an issue where the IPC file that CPP-eth uses for RPC cannot be used externally from the host that is running the container.

Example:
```
docker run -v /tmp/ewasm-node/4201:/tmp/ewasm-node/4201 --ipc=host localhost/cpp-ethereum  > /dev/null 2>&1 &
python3 jsonrpcproxy.py /tmp/ewasm-node/4201/geth.ipc
curl -X POST --data "{\"jsonrpc\":\"2.0\",\"method\":\"eth_sendRawTransaction\",\"params\":[\"f8528085174876e80083100000800a8081a8a08183c7a0aef13ad8513f69a4dafbd48e8700dd228f0243d6290ca8275a0311ada01650bf69d3a8845f9ed91a21c71c1020c9161b96e70abbcd90ea87eaadbd5cbd\"],\"id\":1}" localhost:8545
```

Log output from `jsonrpcproxy.py`:
```
127.0.0.1 - - [19/Feb/2018 22:36:55] "POST / HTTP/1.1" 502 -
127.0.0.1 - - [19/Feb/2018 22:36:55] Backend Error: Unknown error when connecting to '/tmp/ewasm-node/4201/geth.ipc'
```