### PR TITLE
Composable Local Testnets

### DIFF
--- a/docker-compose/Dockerfile
+++ b/docker-compose/Dockerfile
@@ -1,0 +1,4 @@
+FROM ubuntu:xenial
+
+ADD geth /root/
+ADD libhera.so /root/

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -1,0 +1,11 @@
+# ewasm Testnet Local Configuration
+## Setup
+* build go-ethereum, build hera with shared lib mode
+* copy geth binary and libhera.so to this folder
+* execute `build.sh` to build docker images for etherchain-light, ewasm-studio and geth
+* spin up all components `docker-compose up`
+
+## Components
+* Geth - 172.28.0.2
+* Explorer - 172.28.0.3:3000
+* Ewasm Studio - 172.28.0.4

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -95,5 +95,5 @@ done
 	&& cd go-ethereum \
 	&& make && cp build/bin/geth .. )
 
-docker build -t ewasm/go-ethereum .
+docker build -t ewasm/geth-hera .
 ./init-geth.sh

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+set -e
+( git clone https://github.com/ewasm/ewasm-studio && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
+( git clone https://github.com/ewasm/etherchain-light && cd etherchain-light && docker build -t ewasm/etherchain-light . )
+docker build -t ewasm/go-ethereum .

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -3,3 +3,4 @@ set -e
 ( git clone https://github.com/ewasm/ewasm-studio && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
 ( git clone https://github.com/ewasm/etherchain-light && cd etherchain-light && docker build -t ewasm/etherchain-light . )
 docker build -t ewasm/go-ethereum .
+./init-geth.sh

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -78,9 +78,22 @@ while [ "$1" != "" ]; do
 	shift
 done
 
-( git clone $STUDIO_REPO -b $STUDIO_BRANCH && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
-( git clone https://github.com/ewasm/etherchain-light -b $ETHERCHAIN_BRANCH && cd etherchain-light && docker build -t ewasm/etherchain-light . )
-( git clone $HERA_REPO --recursive -b $HERA_BRANCH && cd hera && mkdir build && cmake -DBUILD_SHARED_LIBS=ON && make -j4 && cp src/libhera.so ../.. )
-( git clone $GETH_REPO -b $GETH_BRANCH && cd go-ethereum && make && cp build/bin/geth .. )
+# ( git clone $STUDIO_REPO -b $STUDIO_BRANCH && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
+( git clone https://github.com/ewasm/etherchain-light -b $ETHERCHAIN_BRANCH && \
+	cd etherchain-light && \
+	docker build -t ewasm/etherchain-light . )
+
+( git clone $HERA_REPO --recursive -b $HERA_BRANCH && \
+	cd hera && \
+	mkdir build && \
+	cd build && \
+	cmake -DBUILD_SHARED_LIBS=ON .. && \
+	make -j4 && \
+	cp src/libhera.so ../.. )
+
+( git clone $GETH_REPO -b $GETH_BRANCH \
+	&& cd go-ethereum \
+	&& make && cp build/bin/geth .. )
+
 docker build -t ewasm/go-ethereum .
 ./init-geth.sh

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -2,5 +2,7 @@
 set -e
 ( git clone https://github.com/ewasm/ewasm-studio && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
 ( git clone https://github.com/ewasm/etherchain-light && cd etherchain-light && docker build -t ewasm/etherchain-light . )
+( git clone https://github.com/ewasm/hera --recursive && cd hera && cmake -DBUILD_SHARED_LIBS=ON && make -j4 && cp src/libhera.so .. )
+( git clone https://github.com/ewasm/go-ethereum && cd go-ethereum && make && cp build/bin/geth .. )
 docker build -t ewasm/go-ethereum .
 ./init-geth.sh

--- a/docker-compose/build.sh
+++ b/docker-compose/build.sh
@@ -1,8 +1,86 @@
 #! /bin/bash
 set -e
-( git clone https://github.com/ewasm/ewasm-studio && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
-( git clone https://github.com/ewasm/etherchain-light && cd etherchain-light && docker build -t ewasm/etherchain-light . )
-( git clone https://github.com/ewasm/hera --recursive && cd hera && cmake -DBUILD_SHARED_LIBS=ON && make -j4 && cp src/libhera.so .. )
-( git clone https://github.com/ewasm/go-ethereum && cd go-ethereum && make && cp build/bin/geth .. )
+
+help () {
+	echo "build.sh OPTIONS
+Description:
+		Local Docker development environment for the Ewasm testnet.  Creates configuration to launch a local testnet containing a miner, block explorer and smart contract development environment.
+Usage:
+		--geth-repo - git repository to download geth from. Default: https://github.com/ewasm/go-ethereum
+		--geth-branch - branch of geth to build from. Default: ewasm
+		--hera-repo - git repository to download Hera from. Default: https://github.com/ewasm/hera
+		--hera-branch - branch of hera to build from. Default: master
+		--etherchain-branch - branch of Etherchain light to build. Default: ewasm
+		--etherchain-repo - git repository to download Etherchain light from. Default: https://github.com/ewasm/etherchain-light
+		--studio-branch - branch of ewasm studio to build. Default: master
+		--studio-repo - Git repository to download ewasm studio from. Default: https://github.com/ewasm/ewasm-studio
+"
+}
+
+GETH_BRANCH="ewasm"
+GETH_REPO="https://github.com/ewasm/go-ethereum"
+HERA_BRANCH="master"
+HERA_REPO="https://github.com/ewasm/hera"
+ETHERCHAIN_BRANCH="ewasm"
+ETHERCHAIN_REPO="https://github.com/ewasm/etherchain-light"
+STUDIO_BRANCH="master"
+STUDIO_REPO="https://github.com/ewasm/ewasm-studio"
+
+while [ "$1" != "" ]; do
+	case $1 in
+	--help)
+		help
+		exit 0
+		;;
+	--clean)
+		rm -rf go-ethereum
+		rm -rf hera
+		rm -rf etherchain-light
+		rm -rf ewasm-studio
+		;;
+	--geth-branch)
+		shift
+		GETH_BRANCH=$1
+		;;
+	--geth-repo)
+		shift
+		GETH_REPO=$1
+		;;
+	--hera-branch)
+		shift
+		HERA_BRANCH=$1
+		;;
+	--hera-repo)
+		shift
+		HERA_REPO=$1
+		;;
+	--etherchain-branch)
+		shift
+		ETHERCHAIN_BRANCH=$1
+		;;
+	--etherchain-repo)
+		shift
+		ETHERCHAIN_REPO=$1
+		;;
+	--studio-branch)
+		shift
+		STUDIO_BRANCH=$1
+		;;
+	--studio-repo)
+		shift
+		STUDIO_REPO=$1
+		;;
+	-h | --help)
+		help
+		exit
+		;;
+	esac
+	shift
+done
+
+( git clone $STUDIO_REPO -b $STUDIO_BRANCH && cd ewasm-studio && docker build -t ewasm/ewasm-studio . )
+( git clone https://github.com/ewasm/etherchain-light -b $ETHERCHAIN_BRANCH && cd etherchain-light && docker build -t ewasm/etherchain-light . )
+( git clone $HERA_REPO --recursive -b $HERA_BRANCH && cd hera && mkdir build && cmake -DBUILD_SHARED_LIBS=ON && make -j4 && cp src/libhera.so ../.. )
+( git clone $GETH_REPO -b $GETH_BRANCH && cd go-ethereum && make && cp build/bin/geth .. )
 docker build -t ewasm/go-ethereum .
 ./init-geth.sh

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         user: root
         volumes:
         - ./data/geth-hera:/root/data
-        command: /root/geth --vm.ewasm="/root/libhera.so,metering=true,fallback=true" --syncmode="full" --etherbase a8c3eeb2915373139bcfc287d4ae9e660d734881 --rpc --rpcapi "web3,net,eth,debug" --rpcvhosts=* --rpcaddr "0.0.0.0" --rpccorsdomain "*" --mine --miner.threads 1 --networkid 66 
+        command: /root/geth --vm.ewasm="/root/libhera.so,metering=true,fallback=true" --syncmode="full" --etherbase a8c3eeb2915373139bcfc287d4ae9e660d734881 --rpc --rpcapi "web3,net,eth,debug" --rpcvhosts=* --rpcaddr "0.0.0.0" --rpccorsdomain "*" --mine --miner.threads 1 --networkid 66  --vmodule "miner=12" --datadir /root/data
         networks:
             ewasm:
                 ipv4_address: 172.28.0.2

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -20,6 +20,8 @@ services:
         container_name: etherchain_light
         image: ewasm/etherchain-light
         command: npm start -- --rpc=http://172.28.0.2:8545
+        environment:
+            PORT: 80
         depends_on:
         - "geth_hera"
         networks:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2.0'
+networks:
+  ewasm:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/24
+services:
+    geth_hera:
+        container_name: geth_evmc
+        image: ewasm/geth-hera
+        user: root
+        volumes:
+        - ./data/geth-hera:/root/data
+        command: /root/geth --vm.ewasm="/root/libhera.so,metering=true,fallback=true" --syncmode="full" --etherbase a8c3eeb2915373139bcfc287d4ae9e660d734881 --rpc --rpcapi "web3,net,eth,debug" --rpcvhosts=* --rpcaddr "0.0.0.0" --rpccorsdomain "*" --mine --miner.threads 1 --networkid 66 
+        networks:
+            ewasm:
+                ipv4_address: 172.28.0.2
+    etherchain_light:
+        container_name: etherchain_light
+        image: ewasm/etherchain-light
+        command: npm start -- --rpc=http://172.28.0.2:8545
+        depends_on:
+        - "geth_hera"
+        networks:
+            ewasm:
+                ipv4_address: 172.28.0.3
+    ewasm_studio:
+        container_name: ewasm_studio
+        image: ewasm/ewasm-studio
+        environment:
+            PORT: 80
+        networks:
+            ewasm:
+                ipv4_address: 172.28.0.4

--- a/docker-compose/get-deps.sh
+++ b/docker-compose/get-deps.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+rm -rf hera libhera.so && mkdir hera
+rm -f hera-0.2.3-alpha.0-linux-x86_64.tar.gz
+rm -f geth v1.9.0-evmc.6.1.1-0-unstable.tar.gz go-ethereum-1.9.0-evmc.6.1.1-0-unstable
+
+wget https://github.com/ewasm/hera/releases/download/v0.2.3-alpha.0/hera-0.2.3-alpha.0-linux-x86_64.tar.gz && tar -C hera -xvf hera-0.2.3-alpha.0-linux-x86_64.tar.gz
+cp hera/lib/libhera.so .
+
+wget https://github.com/ewasm/go-ethereum/archive/v1.9.0-evmc.6.1.1-0-unstable.tar.gz && tar -xvf v1.9.0-evmc.6.1.1-0-unstable.tar.gz
+(cd go-ethereum-1.9.0-evmc.6.1.1-0-unstable && make && mv build/bin/geth ..)
+
+docker build -t ewasm/geth-hera .
+./init-geth.sh

--- a/docker-compose/init-geth.sh
+++ b/docker-compose/init-geth.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+mkdir -p data/geth-hera
+./geth init ../ewasm-testnet-geth-config.json --datadir data/geth-hera


### PR DESCRIPTION
The end-goal for this PR is to allow devs to spin up different configurations of testnets locally using docker-compose.

E.g. Say I want a three node testnet with geth-hera, geth-wagon, aleth alongside the testnet tooling.  I could use a script (yet to be written) which will generate the necessary docker configs to spin this up locally.

I'm taking inspiration from https://github.com/paritytech/parity-deploy which does something similar but for parity.